### PR TITLE
Fix magma installer: magma URL and zip contents

### DIFF
--- a/MAGNET_Tool/PreMagnetConfig.sh
+++ b/MAGNET_Tool/PreMagnetConfig.sh
@@ -272,15 +272,15 @@ echo -e "...Checking for the Program MAGMA, if doesn't exist then it will be dow
 	#Change to magma main directory
 	cd $MAGNET/MAIN_DIR/magma
 	#Download magma
-	wget https://ctg.cncr.nl/software/MAGMA/prog/magma_v1.07b.zip --no-check-certificate
-	unzip magma_v1.07b.zip
-	chmod +xr $MAGNET/MAIN_DIR/magma/magma_v1.07b/magma
-	$MAGNET/MAIN_DIR/magma/magma_v1.07b/magma > $MAGNET/LOG/magma.log 2>&1 
-	testp='$MAGNET/MAIN_DIR/magma/magma_v1.07b/magma | grep 'magma''
+	wget https://ctg.cncr.nl/software/MAGMA/prog/magma_v1.07bb.zip --no-check-certificate
+	unzip magma_v1.07bb.zip
+	chmod +xr $MAGNET/MAIN_DIR/magma/magma
+	$MAGNET/MAIN_DIR/magma/magma > $MAGNET/LOG/magma.log 2>&1 
+	testp='$MAGNET/MAIN_DIR/magma/magma | grep -i 'magma''
 		if [[ ! $testp = 0 ]]
 		then
 		echo -e 			"\n ...Magma successfully installed... \n"
-		echo "magma=$MAGNET/MAIN_DIR/magma/magma_v1.07b/magma" >> $MAGNET/ConfigFiles/Tools.config
+		echo "magma=$MAGNET/MAIN_DIR/magma/magma_v1.07bb/magma" >> $MAGNET/ConfigFiles/Tools.config
 		else
 		echo "...Error during magma installation..."
 		tools_installed_ind=0


### PR DESCRIPTION
The download URL and the directory structure of the ZIP file contents for MAGMA have changed, and the current installer script does not work anymore. See https://ctg.cncr.nl/software/MAGMA/prog/, the file name was changed from `magma_v1.07b.zip` to `magma_v1.07bb.zip`, and the old version was silently removed, it seems.

The new zip also does contain the `magma` binary directly, not in a sub directory like the previous one.

The update to the `PreMagnetConfig.sh` script in this PR should fix the installer.