### PR TITLE
install documentation: fix unzip to gunzip for extraction of gz files

### DIFF
--- a/MAGNET_Tool/readme.txt
+++ b/MAGNET_Tool/readme.txt
@@ -43,7 +43,7 @@
 	wget ftp://ftp.ncbi.nlm.nih.gov/snp/organisms/human_9606_b150_GRCh37p13/BED/bed_chr_"$i".bed.gz
 	done
 	chmod 770 *
-	unzip -n bed_chr_*.bed.gz
+	gunzip -n bed_chr_*.bed.gz
 	cat bed_chr_*.bed>SNPs_all.bed
 	rm bed_chr_*
 


### PR DESCRIPTION
A simple typo in the installation instructions for the `RefData` for `MAGNET_Tool`. 

Unpacking `.gz` files won't work with `unzip`, one needs `gunzip`.

I am not sure whether you want to keep the `-n`, it may not be what you want with the gunzip.