### PR TITLE
fix directory name of stage 1 output in Stage2 script

### DIFF
--- a/MAGNET_Tool/Scripts/Stage2_Imputation.sh
+++ b/MAGNET_Tool/Scripts/Stage2_Imputation.sh
@@ -6,7 +6,7 @@ source /$LocSource/ConfigFiles/Tools.config
 source /$LocSource/ConfigFiles/Thresholds.config
 
 
-cd OUTPUT_DIR/Stage1_GenoQC.sh 
+cd OUTPUT_DIR/Stage1_GenoQC 
 
 QCFile=FinalQC_Study #variable assigned to the final QC file from Stage1_GenoQC.sh
 


### PR DESCRIPTION
In the Stage2 script, the directory name for the Stage 1 output contains a typo, and the script fails as a consequence. This PR fixes the directory name.